### PR TITLE
Adding first few links for Angular2 Dart, more to come

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,5 +117,5 @@
 ### Angular 2 Dart
 * [Angular2 Dart API cheatsheet](https://docs.google.com/document/d/1FYyA-b9rc2UtlYyQXjW7lx4Y08MSpuWcbbuqVCxHga0/edit#heading=h.34sus6g4zss3)
 * [Angular2 Dart cheatsheet](https://github.com/andresaraujo/angular2_cheatsheet_dart)
-* [Anglar2 Dart Gnome Tutorial app](https://github.com/sanfordredlich/AngularDartGnomeTutorial)
+* [Angular2 Dart Gnome Tutorial app](https://github.com/sanfordredlich/AngularDartGnomeTutorial)
 * [Angular2 Dart Router demo](https://github.com/rkirov/angular2-dart-router-demo/tree/master/angular2)


### PR DESCRIPTION
Thanks for the great education summary. Do you think adding in Dart is helpful? I could fork and do a Dart-only version but right now most docs are for JS so there's a lot of overlap.