### PR TITLE
add link to official Angular 2 styleguide

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@
 * [DefinitelyTyped](http://definitelytyped.org/tsd/)
 
 ### Best Practices and Style Guidelines
+* [Official Angular 2 Style Guide](https://angular.io/docs/ts/latest/guide/style-guide.html)
 * [Angular 2 Style Guide (by Minko Gechev)](https://mgechev.github.io/angular2-style-guide/)
 
 ### Related Lists


### PR DESCRIPTION
Hi,

this PR adds the link to the official style guide. I left Minko's version as it might still be beneficial, although Minko has also contributed together with John Papa on the official one.